### PR TITLE
Add versioning support & change flag check to DEBUG

### DIFF
--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -93,9 +93,9 @@ extension Endpoint {
         components.scheme = "http"
         components.host = Keys.hostURL.value
         if let apiVersion = Endpoint.apiVersion {
-            components.path = "/api/v\(apiVersion)/\(path)"
+            components.path = "/api/v\(apiVersion)\(path)"
         } else {
-            components.path = "/api/\(path)"
+            components.path = "/api\(path)"
         }
         #if DEBUG
         components.port = 3000

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -45,7 +45,7 @@ enum Keys: String {
 
 
 struct Endpoint {
-    static let apiVersion: Int?
+    static var apiVersion: Int?
 
     let path: String
     let queryItems: [URLQueryItem]

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -45,6 +45,8 @@ enum Keys: String {
 
 
 struct Endpoint {
+    static let apiVersion: Int?
+
     let path: String
     let queryItems: [URLQueryItem]
     let headers: [String: String]
@@ -89,8 +91,12 @@ extension Endpoint {
     var url: URL? {
         var components = URLComponents()
         components.scheme = "http"
-        components.host = "\(Keys.hostURL.value)/api"
-        components.path = path
+        components.host = Keys.hostURL.value
+        if let apiVersion = Endpoint.apiVersion {
+            components.path = "/api/v\(apiVersion)/\(path)"
+        } else {
+            components.path = "/api/\(path)"
+        }
         #if DEBUG
         components.port = 3000
         #endif

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -91,7 +91,7 @@ extension Endpoint {
         components.scheme = "http"
         components.host = "\(Keys.hostURL.value)/api"
         components.path = path
-        #if DEV_SERVER
+        #if DEBUG
         components.port = 3000
         #endif
         components.queryItems = queryItems

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -29,7 +29,7 @@ enum Keys: String {
     }
 
     static var hostURL: Keys {
-        #if DEV_SERVER
+        #if DEBUG
         return Keys.apiDevURL
         #else
         return Keys.apiURL

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a `/Secrets/Keys.plist` plist file in the project directory with the foll
 Replace `example.server` under `api-url` with the host of your backend server 
 
 ## Important Notes
-  * In order for `Endpoint.swift` to work as intended, your project should have the a scheme for **development** and one for **production**. The reason for this is because values in `Endpoint.swift` depend on if `DEV_SERVER` is `true` or `false`. 
+  * In order for `Endpoint.swift` to work as intended, your project should have the a scheme for **development** and one for **production**. The reason for this is because values in `Endpoint.swift` depend on if the `DEBUG` flag is `true` or `false`. 
   * This [article](https://zeemee.engineering/how-to-set-up-multiple-schemes-configurations-in-xcode-for-your-react-native-ios-app-7da4b5237966) explains the whole process of creating a new scheme and integrating into your app really well so it is highly recommended that you check it out!
   * `DEBUG` is `true` when you are running on a development scheme.
   * To create a scheme for development, follow the steps below:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Replace `example.server` under `api-url` with the host of your backend server
 
   ![screen shot 2019-01-28 at 11 37 58 pm](https://user-images.githubusercontent.com/26048121/51884811-d9d0a500-2356-11e9-954a-5e4e83fb35bb.png)
 
-  2. Create a title for your scheme, i.e. `Clicker Debug`. Note that, as the article above describes, you can create your own custom build setting and create a scheme just for that.
+  2. Create a title for your scheme, i.e. `Clicker Debug`. Note that, as the article above describes, you can create your own custom configuration  and create a scheme just for that.
   3. Make sure that the `Build Configuration` for the `Run` tab is `Debug`. Doing this will ensure that whenever you `Run` your application from XCode, `DEBUG` will be true.
   
   ![screen shot 2019-02-03 at 1 04 23 am](https://user-images.githubusercontent.com/26048121/52173293-b1c6b480-274f-11e9-97dc-c2d73d8150cb.png)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Replace `example.server` under `api-url` with the host of your backend server
 
 ## Important Notes
   * In order for `Endpoint.swift` to work as intended, your project should have the a scheme for **development** and one for **production**. The reason for this is because values in `Endpoint.swift` depend on if the `DEBUG` flag is `true` or `false`. 
-  * This [article](https://zeemee.engineering/how-to-set-up-multiple-schemes-configurations-in-xcode-for-your-react-native-ios-app-7da4b5237966) explains the whole process of creating a new scheme and integrating into your app really well so it is highly recommended that you check it out!
+  * This [article](https://zeemee.engineering/how-to-set-up-multiple-schemes-configurations-in-xcode-for-your-react-native-ios-app-7da4b5237966) explains the whole process of creating a new scheme and integrating into your app really well so it is highly recommended that you check it out! This [stack overflow post](https://stackoverflow.com/questions/38813906/swift-how-to-use-preprocessor-flags-like-if-debug-to-implement-api-keys) is also good to look at if you want to understand how to add custom conditional swift compilation flags.
   * `DEBUG` is `true` when you are running on a development scheme.
   * To create a scheme for development, follow the steps below:
   1. Click on `New Scheme`

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Replace `http://example.server.com` under `api-url` with the host of your backen
 
 ## Important Notes
   * In order for `Endpoint.swift` to work as intended, your project should have the a scheme for **development** and one for **production**. The reason for this is because values in `Endpoint.swift` depend on if `DEV_SERVER` is `true` or `false`. 
-  * `DEV_SERVER` is `true` when you are running on a development scheme.
+  * This [article](https://zeemee.engineering/how-to-set-up-multiple-schemes-configurations-in-xcode-for-your-react-native-ios-app-7da4b5237966) explains the whole process of creating a new scheme and integrating into your app really well so it is highly recommended that you check it out!
+  * `DEBUG` is `true` when you are running on a development scheme.
   * To create a scheme for development, follow the steps below:
   1. Click on `New Scheme`
-  2. Create a title for your scheme, i.e. `Clicker Dev Server`.
-  3. Make sure that the `Build Configuration` for the `Run` tab is `Debug Dev Server`.
+  2. Create a title for your scheme, i.e. `Clicker Debug`. Note that, as the article above describes, you can create your own custom build setting and create a scheme just for that.
+  3. Make sure that the `Build Configuration` for the `Run` tab is `Debug`. Doing this will ensure that whenever you `Run` your application from XCode, `DEBUG` will be true.
   * To create a scheme for production, repeat the steps above except that the `Build Configuration` for the `Run` tab should be `Debug`.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Replace `example.server` under `api-url` with the host of your backend server
   * To create a scheme for development, follow the steps below:
   1. Click on `New Scheme`
 
-  ![screen shot 2019-02-03 at 1 04 23 am](https://user-images.githubusercontent.com/26048121/52173293-b1c6b480-274f-11e9-97dc-c2d73d8150cb.png)
+  ![screen shot 2019-01-28 at 11 37 58 pm](https://user-images.githubusercontent.com/26048121/51884811-d9d0a500-2356-11e9-954a-5e4e83fb35bb.png)
 
   2. Create a title for your scheme, i.e. `Clicker Debug`. Note that, as the article above describes, you can create your own custom build setting and create a scheme just for that.
   3. Make sure that the `Build Configuration` for the `Run` tab is `Debug`. Doing this will ensure that whenever you `Run` your application from XCode, `DEBUG` will be true.
   
-  ![screen shot 2019-01-28 at 11 36 40 pm](https://user-images.githubusercontent.com/26048121/51884832-e81ec100-2356-11e9-89d0-c12b19545769.png)
+  ![screen shot 2019-02-03 at 1 04 23 am](https://user-images.githubusercontent.com/26048121/52173293-b1c6b480-274f-11e9-97dc-c2d73d8150cb.png)
   * To create a scheme for production, repeat the steps above except that the `Build Configuration` for the `Run` tab should be `Debug`.


### PR DESCRIPTION
- I thought that `DEBUG_DEV_SERVER` was a build configuration that all apps have but turns out it was a custom one added to Pollo so I changed the check from `#IF DEBUG_DEV_SERVER` to `DEBUG`
- Linked a great article explaining the process of creating a new scheme/configuration really well an updated README
- Added & fixed versioning support