### PR TITLE
Fix general Endpoint method init

### DIFF
--- a/FutureNova.podspec
+++ b/FutureNova.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FutureNova'
-  s.version          = '0.1.2'
+  s.version          = '0.1.4'
   s.summary          = 'A simple networking wrapper using Futures and Promises.'
 
 # This description is used to generate tags and improve search results.

--- a/FutureNova/Classes/Endpoint.swift
+++ b/FutureNova/Classes/Endpoint.swift
@@ -30,6 +30,7 @@ extension Endpoint {
         case get = "GET"
         case post = "POST"
         case delete = "DELETE"
+        case put = "PUT"
     }
 
     public class Config {
@@ -43,7 +44,7 @@ extension Endpoint {
 
 // Endpoint initializers
 extension Endpoint {
-    /// General initializer
+    /// General initializer with body
     public init<T: Codable>(path: String,
                             queryItems: [URLQueryItem] = [],
                             headers: [String: String] = [:],
@@ -56,10 +57,41 @@ extension Endpoint {
                             customPort: Int? = nil) {
         self.path = path
         self.queryItems = queryItems
-        self.headers = headers
-        self.method = (body != nil) ? .post : method
+
+        var modifiedHeaders = headers
+        if modifiedHeaders["Content-Type"] == nil {
+            // Set Content-Type to application/json so backend can identify json body
+            modifiedHeaders["Content-Type"] = "application/json"
+        }
+        self.headers = modifiedHeaders
+
+        self.method = method
         self.body = try? JSONEncoder().encode(body)
 
+        self.host = customHost
+        self.port = customPort
+        self.scheme = customScheme
+        self.useCommonPath = useCommonPath
+        self.useCommonHeaders = useCommonHeaders
+    }
+
+    /// General initializer without body
+    public init(path: String,
+                            queryItems: [URLQueryItem] = [],
+                            headers: [String: String] = [:],
+                            method: Endpoint.Method = .get,
+                            useCommonHeaders: Bool = true,
+                            useCommonPath: Bool = true,
+                            customHost: String? = nil,
+                            customScheme: String? = nil,
+                            customPort: Int? = nil) {
+        self.path = path
+        self.queryItems = queryItems
+
+        self.headers = headers
+
+        self.method = method
+        self.body = nil
         self.host = customHost
         self.port = customPort
         self.scheme = customScheme

--- a/FutureNova/Classes/Endpoint.swift
+++ b/FutureNova/Classes/Endpoint.swift
@@ -65,11 +65,7 @@ extension Endpoint {
         }
         self.headers = modifiedHeaders
 
-<<<<<<< HEAD
         self.method = method
-=======
-        self.method = (body != nil) ? .post : method
->>>>>>> origin
         self.body = try? JSONEncoder().encode(body)
 
         self.host = customHost


### PR DESCRIPTION
- Previously, if the body isn't nil, the method defaulted to `POST` as opposed to the method supplied in the init
- This caused errors with `PUT` requests