### PR TITLE
Updates to Swift 4.2 and adds GraphQL support

### DIFF
--- a/Example/FutureNova.xcodeproj/project.pbxproj
+++ b/Example/FutureNova.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		6D31D9C6228613580007AA0B /* GraphQLExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31D9C5228613580007AA0B /* GraphQLExample.swift */; };
 		6D36736922257F93000F9917 /* DogEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D36736822257F93000F9917 /* DogEndpoints.swift */; };
 		88D83382652320D5ED6B2C7A /* Pods_FutureNova_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A722DEAF8E4404C2A42C893D /* Pods_FutureNova_Example.framework */; };
 /* End PBXBuildFile section */
@@ -39,6 +40,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		61F62604B2C0C830296E20CC /* Pods-FutureNova_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FutureNova_Tests.release.xcconfig"; path = "Target Support Files/Pods-FutureNova_Tests/Pods-FutureNova_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		6D31D9C5228613580007AA0B /* GraphQLExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLExample.swift; sourceTree = "<group>"; };
 		6D36736822257F93000F9917 /* DogEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogEndpoints.swift; sourceTree = "<group>"; };
 		785C74814A23EAA61EB6D7C7 /* Pods_FutureNova_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FutureNova_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		79B13059958FD856AAC0AAC5 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 			children = (
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				6D36736822257F93000F9917 /* DogEndpoints.swift */,
+				6D31D9C5228613580007AA0B /* GraphQLExample.swift */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -207,18 +210,18 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = ZGMCXU7X3U;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = ZGMCXU7X3U;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -337,6 +340,7 @@
 			files = (
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				6D36736922257F93000F9917 /* DogEndpoints.swift in Sources */,
+				6D31D9C6228613580007AA0B /* GraphQLExample.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -383,12 +387,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -416,7 +422,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -436,12 +442,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -462,7 +470,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -482,8 +490,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -499,8 +506,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -521,8 +527,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FutureNova_Example.app/FutureNova_Example";
 			};
 			name = Debug;
@@ -540,8 +545,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FutureNova_Example.app/FutureNova_Example";
 			};
 			name = Release;

--- a/Example/FutureNova.xcodeproj/xcshareddata/xcschemes/FutureNova-Example.xcscheme
+++ b/Example/FutureNova.xcodeproj/xcshareddata/xcschemes/FutureNova-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/FutureNova/AppDelegate.swift
+++ b/Example/FutureNova/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         endpointConfig()
 
@@ -29,6 +29,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Endpoint.config.scheme = "https"
         Endpoint.config.host = "dog.ceo"
         Endpoint.config.commonPath = "/api"
+
+        // Uncomment for GraphQL
+//        Endpoint.config.scheme = "https"
+//        Endpoint.config.host = "" // ADD EATERY URL HERE
+//        Endpoint.config.commonPath = "/"
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Example/FutureNova/DogEndpoints.swift
+++ b/Example/FutureNova/DogEndpoints.swift
@@ -20,5 +20,5 @@ extension Endpoint {
     static func dogBreedImage(breed: String, id: String) -> Endpoint {
         return Endpoint(path: "/breeds/\(breed)/\(id)", useCommonPath: false, customHost: "images.dog.ceo")
     }
-    
+
 }

--- a/Example/FutureNova/GraphQLExample.swift
+++ b/Example/FutureNova/GraphQLExample.swift
@@ -1,0 +1,67 @@
+//
+//  GraphQLExample.swift
+//  FutureNova_Example
+//
+//  Created by Drew Dunne on 5/10/19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import FutureNova
+
+extension Endpoint {
+
+    static func getEateries(id: Int?) -> Endpoint {
+        let args = id != nil ? ["id": id!] : nil
+        return graphQLEndpoint("eateries", args: args, nestedResponse: Eatery.self)
+    }
+
+}
+
+enum EateryError: Error {
+    case error
+}
+
+enum PaymentMethods: String, Codable, CaseIterable, GraphQLDecodable {
+    case brb = "BRB"
+    case cash = "CASH"
+    case credit = "CREDIT"
+    case cornellCard = "CORNELL_CARD"
+    case mobile = "MOBILE"
+    case swipes = "SWIPES"
+}
+
+struct FoodStation: Codable {
+    let category: String
+}
+
+struct FoodCategory: Codable {
+    let category: String
+    let stations: [FoodStation]
+}
+
+struct Eatery: Codable {
+    let id: Int
+    let name: String
+    let paymentMethodsEnums: [PaymentMethods]
+    let expandedMenu: [FoodCategory]
+}
+
+struct EateryResp: Codable {
+    let eateries: [Eatery]
+}
+
+struct APIErrors: Codable {
+    let message: String
+    let locations: [Location]
+
+    struct Location: Codable {
+        let line: Int
+        let column: Int
+    }
+}
+
+struct APIResponse<T: Codable>: Codable {
+    let data: T?
+    let errors: [APIErrors]?
+}

--- a/Example/FutureNova/ViewController.swift
+++ b/Example/FutureNova/ViewController.swift
@@ -53,6 +53,19 @@ class ViewController: UIViewController {
                     self?.presentError(with: error)
                 }
         }
+
+        getNastysEatery().chained { apiResp -> Future<[Eatery]> in
+                print(apiResp)
+                guard let data = apiResp.data else { return Promise<[Eatery]>(error: EateryError.error) }
+                return Promise<[Eatery]>(value: data.eateries)
+            }.observe { resp in
+                switch resp {
+                case .value(let eateries):
+                    print(eateries)
+                case .error(let err):
+                    print(err)
+                }
+        }
     }
 
     func presentError(with error: Error) {
@@ -67,6 +80,10 @@ class ViewController: UIViewController {
 
     private func getRandomImage() -> Future<RandomDogResponse> {
         return networking(Endpoint.randomDogBreed()).decode()
+    }
+
+    private func getNastysEatery() -> Future<APIResponse<EateryResp>> {
+        return networking(Endpoint.getEateries(id: 1)).decode()
     }
 
     override func didReceiveMemoryWarning() {

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		3CB9366CDFE7E3EEA800CFE18FBE456D /* Pods-FutureNova_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 107E8BC5A704E70BCEA81CF1A2C802A6 /* Pods-FutureNova_Tests-dummy.m */; };
 		47AA5BF6C8A14194EF5A7F5390349820 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */; };
 		516BFB063CB108FC2C08633D7CF9184E /* FutureNova-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 52CDE957E1F4B2C460167F40AE429A68 /* FutureNova-dummy.m */; };
+		6D31D9BC228609BB0007AA0B /* GraphQLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31D9BB228609BB0007AA0B /* GraphQLEncoder.swift */; };
+		6D31D9BE228609F90007AA0B /* Decodable+GraphQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31D9BD228609F90007AA0B /* Decodable+GraphQL.swift */; };
+		6D31D9C022860A380007AA0B /* GraphQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31D9BF22860A380007AA0B /* GraphQL.swift */; };
+		6D31D9C222860BE10007AA0B /* GraphQLDecoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31D9C122860BE10007AA0B /* GraphQLDecoders.swift */; };
+		6D31D9C422860D2E0007AA0B /* GraphQLDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31D9C322860D2E0007AA0B /* GraphQLDecodable.swift */; };
 		6D36736622205C55000F9917 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D36736422205C55000F9917 /* Endpoint.swift */; };
 		6D36736722205C55000F9917 /* Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D36736522205C55000F9917 /* Future.swift */; };
 		7848D43A04C20258BB343FF145E0EC5D /* Pods-FutureNova_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D62FCDE41DB600084F42D32840419492 /* Pods-FutureNova_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -50,6 +55,11 @@
 		5960A19700B2FE1327EB7ED0086E0D61 /* Pods-FutureNova_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FutureNova_Example-frameworks.sh"; sourceTree = "<group>"; };
 		63D4EA9A083EFFE594F8E52AEB60C228 /* Pods-FutureNova_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FutureNova_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		6BE3BF111F133B4282812F1C9ED4951A /* Pods-FutureNova_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FutureNova_Example.release.xcconfig"; sourceTree = "<group>"; };
+		6D31D9BB228609BB0007AA0B /* GraphQLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GraphQLEncoder.swift; path = FutureNova/Classes/GraphQLEncoder.swift; sourceTree = "<group>"; };
+		6D31D9BD228609F90007AA0B /* Decodable+GraphQL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Decodable+GraphQL.swift"; path = "FutureNova/Classes/Decodable+GraphQL.swift"; sourceTree = "<group>"; };
+		6D31D9BF22860A380007AA0B /* GraphQL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GraphQL.swift; path = FutureNova/Classes/GraphQL.swift; sourceTree = "<group>"; };
+		6D31D9C122860BE10007AA0B /* GraphQLDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GraphQLDecoders.swift; path = FutureNova/Classes/GraphQLDecoders.swift; sourceTree = "<group>"; };
+		6D31D9C322860D2E0007AA0B /* GraphQLDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GraphQLDecodable.swift; path = FutureNova/Classes/GraphQLDecodable.swift; sourceTree = "<group>"; };
 		6D36736422205C55000F9917 /* Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Endpoint.swift; path = FutureNova/Classes/Endpoint.swift; sourceTree = "<group>"; };
 		6D36736522205C55000F9917 /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = FutureNova/Classes/Future.swift; sourceTree = "<group>"; };
 		8DEB6EC1B1DD639F45DEC7BE9F67C7DC /* Pods-FutureNova_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FutureNova_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -173,6 +183,11 @@
 			children = (
 				6D36736422205C55000F9917 /* Endpoint.swift */,
 				6D36736522205C55000F9917 /* Future.swift */,
+				6D31D9BF22860A380007AA0B /* GraphQL.swift */,
+				6D31D9BB228609BB0007AA0B /* GraphQLEncoder.swift */,
+				6D31D9C122860BE10007AA0B /* GraphQLDecoders.swift */,
+				6D31D9C322860D2E0007AA0B /* GraphQLDecodable.swift */,
+				6D31D9BD228609F90007AA0B /* Decodable+GraphQL.swift */,
 				0AE8D963DD2B53FB077598FBD84C2655 /* Pod */,
 				7CD6FF20B6ABDC35C7CF69F689452BA3 /* Support Files */,
 			);
@@ -318,6 +333,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0930;
+				TargetAttributes = {
+					82B9F31FA52D1B1CFBF7C6FD104234D8 = {
+						LastSwiftMigration = 1010;
+					};
+				};
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -384,8 +404,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				516BFB063CB108FC2C08633D7CF9184E /* FutureNova-dummy.m in Sources */,
+				6D31D9C022860A380007AA0B /* GraphQL.swift in Sources */,
 				6D36736622205C55000F9917 /* Endpoint.swift in Sources */,
+				6D31D9C422860D2E0007AA0B /* GraphQLDecodable.swift in Sources */,
+				6D31D9BC228609BB0007AA0B /* GraphQLEncoder.swift in Sources */,
 				6D36736722205C55000F9917 /* Future.swift in Sources */,
+				6D31D9BE228609F90007AA0B /* Decodable+GraphQL.swift in Sources */,
+				6D31D9C222860BE10007AA0B /* GraphQLDecoders.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -587,7 +612,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/FutureNova/FutureNova-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/FutureNova/FutureNova-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/FutureNova/FutureNova.modulemap";
 				PRODUCT_MODULE_NAME = FutureNova;
@@ -595,7 +620,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -619,7 +644,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/FutureNova/FutureNova-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/FutureNova/FutureNova-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/FutureNova/FutureNova.modulemap";
 				PRODUCT_MODULE_NAME = FutureNova;
@@ -627,7 +652,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/FutureNova.podspec
+++ b/FutureNova.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FutureNova'
-  s.version          = '0.1.4'
+  s.version          = '0.1.5'
   s.summary          = 'A simple networking wrapper using Futures and Promises.'
 
 # This description is used to generate tags and improve search results.
@@ -24,7 +24,7 @@ A simple networking wrapper using Futures and Promises.
   s.homepage         = 'https://github.com/cuappdev/ios-networking'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Cornell AppDev' => 'cornellappdev@gmail.com' }
+  s.author           = { 'Cornell AppDev' => 'team@cornellappdev.com' }
   s.source           = { :git => 'https://github.com/cuappdev/ios-networking.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 

--- a/FutureNova/Classes/Decodable+GraphQL.swift
+++ b/FutureNova/Classes/Decodable+GraphQL.swift
@@ -1,0 +1,129 @@
+//
+//  Decodable+GraphQL.swift
+//  FutureNova
+//
+//  Created by Drew Dunne on 5/10/19.
+//
+
+import Foundation
+
+extension Decodable {
+    /// Decodes all `CodableProperty`s for this type. This requires that all propeties on this type are `GraphQLDecodable`.
+    ///
+    /// This is used to provide a default implementation for `reflectProperties(depth:)` on `Reflectable`.
+    ///
+    /// - parameters: depth: The level of nesting to use.
+    ///                      If `0`, the top-most properties will be returned.
+    ///                      If `1`, the first layer of nested properties, and so-on.
+    /// - throws: Any error decoding this type's properties.
+    /// - returns: All `GraphQLProperty`s at the specified depth.
+    public static func decodeProperties(depth: Int) throws -> [GraphQLProperty] {
+        let context = GraphQLDecoderContext(activeOffset: 0, maxDepth: 42)
+        let decoder = GraphQLDecoder(codingPath: [], context: context)
+        _ = try Self(from: decoder)
+        return context.properties.filter { $0.path.count == depth + 1 }
+    }
+
+    /// Decodes all `CodableProperty`s for this type. This requires that all propeties on this type are `GraphQLDecodable`.
+    ///
+    /// This is used to provide a default implementation for `reflectProperties(depth:)` on `Reflectable`.
+    ///
+    /// - throws: Any error decoding this type's properties.
+    /// - returns: All `GraphQLProperty`s at the specified depth.
+    public static func decodeProperties() throws -> [GraphQLProperty] {
+        let context = GraphQLDecoderContext(activeOffset: 0, maxDepth: 42)
+        let decoder = GraphQLDecoder(codingPath: [], context: context)
+        _ = try Self(from: decoder)
+        return context.properties
+    }
+
+    /// Decodes a `CodableProperty` for the supplied `KeyPath`. This requires that all propeties on this
+    /// type are `GraphQLDecodable`.
+    ///
+    /// This is used to provide a default implementation for `reflectProperty(forKey:)` on `Reflectable`.
+    ///
+    /// - parameters:
+    ///     - keyPath: `KeyPath` to decode a property for.
+    /// - throws: Any error decoding this property.
+    /// - returns: `GraphQLProperty` if one was found.
+//    public static func decodeProperty<T>(forKey keyPath: KeyPath<Self, T>) throws -> GraphQLProperty? {
+//        return try anyDecodeProperty(valueType: T.self, keyPath: keyPath)
+//    }
+
+    /// Decodes a `CodableProperty` for the supplied `KeyPath`. This requires that all propeties on this
+    /// type are `GraphQLDecodable`.
+    ///
+    /// This is used to provide a default implementation for `reflectProperty(forKey:)` on `Reflectable`.
+    ///
+    /// - parameters:
+    ///     - keyPath: `AnyKeyPath` to decode a property for.
+    /// - throws: Any error decoding this property.
+//    public static func anyDecodeProperty(valueType: Any.Type, keyPath: AnyKeyPath) throws -> GraphQLProperty? {
+//        guard valueType is AnyGraphQLDecodable.Type else {
+//            throw GraphQLError(msg: "`\(valueType)` does not conform to `GraphQLDecodable`.")
+//        }
+//
+//        if let cached = GraphQLPropertyCache.storage[keyPath] {
+//            return cached
+//        }
+//
+//        var maxDepth = 0
+//        a: while true {
+//            defer { maxDepth += 1 }
+//            var activeOffset = 0
+//
+//            if maxDepth > 42 {
+//                return nil
+//            }
+//
+//            b: while true {
+//                defer { activeOffset += 1 }
+//                let context = GraphQLDecoderContext(activeOffset: activeOffset, maxDepth: maxDepth)
+//                let decoder = GraphQLDecoder(codingPath: [], context: context)
+//
+//                let decoded = try Self(from: decoder)
+//                guard let codingPath = context.activeCodingPath else {
+//                    // no more values are being set at this depth
+//                    break b
+//                }
+//
+//                guard let t = valueType as? AnyGraphQLDecodable.Type, let left = decoded[keyPath: keyPath] else {
+//                    break b
+//                }
+//
+//                if try t.anyReflectDecodedIsLeft(left) {
+//                    let property = GraphQLProperty(any: valueType, at: codingPath.map { $0.stringValue })
+//                    GraphQLPropertyCache.storage[keyPath] = property
+//                    return property
+//                }
+//            }
+//        }
+//    }
+}
+
+/// Caches derived `GraphQLProperty`s so that they only need to be decoded once per thread.
+final class GraphQLPropertyCache {
+    /// Thread-specific shared storage.
+    static var storage: [AnyKeyPath: GraphQLProperty] {
+        get {
+            let cache = GraphQLPropertyCache.cache
+            return cache.storage
+        }
+        set {
+            let cache = GraphQLPropertyCache.cache
+            cache.storage = newValue
+            GraphQLPropertyCache.cache = cache
+        }
+    }
+
+    /// Private `ThreadSpecificVariable` powering this cache.
+    private static var cache: GraphQLPropertyCache = .init()
+
+    /// Instance storage.
+    private var storage: [AnyKeyPath: GraphQLProperty]
+
+    /// Creates a new `GraphQLPropertyCache`.
+    init() {
+        self.storage = [:]
+    }
+}

--- a/FutureNova/Classes/GraphQL.swift
+++ b/FutureNova/Classes/GraphQL.swift
@@ -1,0 +1,54 @@
+//
+//  GraphQL.swift
+//  FutureNova
+//
+//  Created by Drew Dunne on 5/10/19.
+//
+
+import Foundation
+
+/// Errors thrown through the GraphQL process
+public struct GraphQLError: Error {
+    /// The error message
+    public var msg: String
+}
+
+/// Represents a property on a type that has been reflected using the `GraphQLCodable` protocol.
+public struct GraphQLProperty {
+    /// This property's type.
+    public let type: Any.Type
+
+    /// The path to this property.
+    public let path: [String]
+
+    /// Creates a new `GraphQLProperty` from a type and path.
+    public init<T>(_ type: T.Type, at path: [String]) {
+        self.type = T.self
+        self.path = path
+    }
+
+    /// Creates a new `GraphQLProperty` using `Any.Type` and a path.
+    public init(any type: Any.Type, at path: [String]) {
+        self.type = type
+        self.path = path
+    }
+}
+
+extension GraphQLProperty: CustomStringConvertible {
+    /// See `CustomStringConvertible.description`
+    public var description: String {
+        return "\(path.joined(separator: ".")): \(type)"
+    }
+}
+
+extension Endpoint {
+
+    /// Simple function for creating a GraphQL version of the Endpoint struct
+    public static func graphQLEndpoint(_ name: String,
+                                       args: [String: CustomStringConvertible]? = nil,
+                                       nestedResponse respClass: Decodable.Type) -> Endpoint {
+        let graphQl = GraphQLEncoder.encode(name: name, args: args, nestedResponse: respClass)
+        return Endpoint(path: "/", queryItems: [URLQueryItem(name: "query", value: graphQl)])
+    }
+
+}

--- a/FutureNova/Classes/GraphQLDecodable.swift
+++ b/FutureNova/Classes/GraphQLDecodable.swift
@@ -1,0 +1,162 @@
+//
+//  GraphQLDecodable.swift
+//  FutureNova
+//
+//  Created by Drew Dunne on 5/10/19.
+//
+
+import Foundation
+
+/// Protocol to allow encoding a GraphQL query
+public protocol GraphQLDecodable: AnyGraphQLDecodable {
+    /// A function that creates a basic instantiation, the values do not matter
+    ///
+    /// - returns: A basic instantiation
+    static func emptyDecoded() throws -> Self
+}
+
+// MARK: Types
+
+extension String: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> String { return "0" }
+    
+}
+
+extension FixedWidthInteger {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> Self { return 0 }
+}
+
+extension UInt: GraphQLDecodable { }
+extension UInt8: GraphQLDecodable { }
+extension UInt16: GraphQLDecodable { }
+extension UInt32: GraphQLDecodable { }
+extension UInt64: GraphQLDecodable { }
+
+extension Int: GraphQLDecodable { }
+extension Int8: GraphQLDecodable { }
+extension Int16: GraphQLDecodable { }
+extension Int32: GraphQLDecodable { }
+extension Int64: GraphQLDecodable { }
+
+extension Bool: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> Bool { return false }
+}
+
+extension BinaryFloatingPoint {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> Self { return 0 }
+}
+
+extension Decimal: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> Decimal { return 0 }
+}
+
+extension Float: GraphQLDecodable { }
+extension Double: GraphQLDecodable { }
+
+extension UUID: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> UUID {
+        return UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+    }
+}
+
+extension Data: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> Data { return Data([0x00]) }
+}
+
+extension Date: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() -> Date { return Date(timeIntervalSince1970: 1) }
+}
+
+extension Optional: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() throws -> Wrapped? {
+        let reflected = try forceCast(Wrapped.self).anyEmptyDecoded()
+        return reflected as? Wrapped
+    }
+}
+
+extension Array: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() throws -> [Element] {
+        let reflected = try forceCast(Element.self).anyEmptyDecoded()
+        return [reflected as! Element]
+    }
+}
+
+extension Dictionary: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() throws -> [Key: Value] {
+        let reflectedValue = try forceCast(Value.self).anyEmptyDecoded()
+        let reflectedKey = try forceCast(Key.self).anyEmptyDecoded()
+        let key = reflectedKey as! Key
+        return [key: reflectedValue as! Value]
+    }
+}
+
+extension Set: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() throws -> Set<Element> {
+        let reflected = try forceCast(Element.self).anyEmptyDecoded()
+        return [reflected as! Element]
+    }
+}
+
+extension URL: GraphQLDecodable {
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func emptyDecoded() throws -> URL { return URL(string: "https://fake.url")! }
+}
+
+// MARK: Type Erased
+
+/// Type-erased version of `GraphQLDecodable`
+public protocol AnyGraphQLDecodable {
+    /// Type-erased version of `GraphQLDecodable.emptyDecoded()`.
+    ///
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    static func anyEmptyDecoded() throws -> Any
+}
+
+extension GraphQLDecodable {
+    /// Type-erased version of `GraphQLDecodable.emptyDecoded()`.
+    ///
+    /// See `GraphQLDecodable.emptyDecoded()` for more information.
+    public static func anyEmptyDecoded() throws -> Any {
+        return try emptyDecoded()
+    }
+}
+
+/// Trys to cast a type to `AnyGraphQLDecodable.Type`. This can be removed when conditional conformance supports runtime querying.
+func forceCast<T>(_ type: T.Type) throws -> AnyGraphQLDecodable.Type {
+    guard let casted = T.self as? AnyGraphQLDecodable.Type else {
+        throw GraphQLError(msg: "\(T.self) is not `GraphQLDecodable`")
+    }
+    return casted
+}
+
+#if swift(>=4.1.50)
+#else
+public protocol CaseIterable {
+    static var allCases: [Self] { get }
+}
+#endif
+
+extension GraphQLDecodable where Self: CaseIterable {
+    /// Default implementation of `GraphQLDecodable` for enums that are also `CaseIterable`.
+    ///
+    /// See `GraphQLDecodable.emptyDecoded(_:)` for more information.
+    public static func emptyDecoded() throws -> Self {
+        /// enum must have at least 2 unique cases
+        guard let first = allCases.first else {
+                throw GraphQLError(msg: "\(Self.self) enum must have at least 1 case")
+        }
+        return first
+    }
+}

--- a/FutureNova/Classes/GraphQLDecoders.swift
+++ b/FutureNova/Classes/GraphQLDecoders.swift
@@ -1,0 +1,216 @@
+//
+//  GraphQLDecoders.swift
+//  FutureNova
+//
+//  Created by Drew Dunne on 5/10/19.
+//
+
+import Foundation
+
+/// Reference class for collecting information about `Decodable` types when initializing them.
+final class GraphQLDecoderContext {
+    /// If set, this is the `CodingKey` path to the truthy value in the initialized model.
+    var activeCodingPath: [CodingKey]?
+
+    /// Sets a maximum depth for decoding nested types like optionals and structs. This value ensures
+    /// that models with recursive structures can be decoded without looping infinitely.
+    var maxDepth: Int
+
+    /// An array of all properties seen while initilaizing the `Decodable` type.
+    var properties: [GraphQLProperty]
+
+    /// If `true`, the property be decoded currently should be set to a truthy value.
+    /// This property will cycle each time it is called.
+    var isActive: Bool {
+        defer { currentOffset += 1 }
+        return currentOffset == activeOffset
+    }
+
+    /// This decoder context's curent active offset. This will determine which property gets
+    /// set to a truthy value while decoding.
+    private var activeOffset: Int
+
+    /// Current offset. This is equal to the number of times `isActive` has been called so far.
+    private var currentOffset: Int
+
+    /// Creates a new `GraphQLDecoderContext`.
+    init(activeOffset: Int, maxDepth: Int) {
+        self.activeCodingPath = nil
+        self.maxDepth = maxDepth
+        self.properties = []
+        self.activeOffset = activeOffset
+        currentOffset = 0
+    }
+
+    /// Adds a property to this `GraphQLDecoderContext`.
+    func addProperty<T>(type: T.Type, at path: [CodingKey]) {
+        let path = path.map { $0.stringValue }
+        // remove any duplicates, favoring the new type
+        properties = properties.filter { $0.path != path }
+        let property = GraphQLProperty.init(T.self, at: path)
+        properties.append(property)
+    }
+}
+
+/// Main decoder for codable reflection.
+struct GraphQLDecoder: Decoder {
+    var codingPath: [CodingKey]
+    var context: GraphQLDecoderContext
+    var userInfo: [CodingUserInfoKey: Any] { return [:] }
+
+    init(codingPath: [CodingKey], context: GraphQLDecoderContext) {
+        self.codingPath = codingPath
+        self.context = context
+    }
+
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        return .init(GraphQLKeyedDecoder<Key>(codingPath: codingPath, context: context))
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return GraphQLUnkeyedDecoder(codingPath: codingPath, context: context)
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return GraphQLSingleValueDecoder(codingPath: codingPath, context: context)
+    }
+}
+
+/// Single value decoder for codable GraphQL.
+struct GraphQLSingleValueDecoder: SingleValueDecodingContainer {
+    var codingPath: [CodingKey]
+    var context: GraphQLDecoderContext
+
+    init(codingPath: [CodingKey], context: GraphQLDecoderContext) {
+        self.codingPath = codingPath
+        self.context = context
+    }
+
+    func decodeNil() -> Bool {
+        return false
+    }
+
+    func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+        context.addProperty(type: T.self, at: codingPath)
+        let type = try forceCast(T.self)
+        let empty = try type.anyEmptyDecoded()
+        if context.isActive {
+            context.activeCodingPath = codingPath
+            return empty as! T
+        }
+        return empty as! T
+    }
+}
+
+/// Keyed decoder for codable graphQL.
+final class GraphQLKeyedDecoder<K>: KeyedDecodingContainerProtocol where K: CodingKey {
+    typealias Key = K
+    var allKeys: [K] { return [] }
+    var codingPath: [CodingKey]
+    var context: GraphQLDecoderContext
+    var nextIsOptional: Bool
+
+    init(codingPath: [CodingKey], context: GraphQLDecoderContext) {
+        self.codingPath = codingPath
+        self.context = context
+        self.nextIsOptional = false
+    }
+
+    func contains(_ key: K) -> Bool {
+        nextIsOptional = true
+        return true
+    }
+
+    func decodeNil(forKey key: K) throws -> Bool {
+        if context.maxDepth > codingPath.count {
+            return false
+        }
+        return true
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+        return .init(GraphQLKeyedDecoder<NestedKey>(codingPath: codingPath + [key], context: context))
+    }
+
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        return GraphQLUnkeyedDecoder(codingPath: codingPath + [key], context: context)
+    }
+
+    func superDecoder() throws -> Decoder {
+        return GraphQLDecoder(codingPath: codingPath, context: context)
+    }
+
+    func superDecoder(forKey key: K) throws -> Decoder {
+        return GraphQLDecoder(codingPath: codingPath + [key], context: context)
+    }
+
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T : Decodable {
+        if nextIsOptional {
+            context.addProperty(type: T?.self, at: codingPath + [key])
+            nextIsOptional = false
+        } else {
+            context.addProperty(type: T.self, at: codingPath + [key])
+        }
+        if let type = T.self as? AnyGraphQLDecodable.Type, let empty = try? type.anyEmptyDecoded() {
+            if context.isActive {
+                context.activeCodingPath = codingPath + [key]
+                return empty as! T
+            }
+            return empty as! T
+        } else {
+            let decoder = GraphQLDecoder(codingPath: codingPath + [key], context: context)
+            return try T(from: decoder)
+        }
+    }
+}
+
+/// Unkeyed decoder for codable graphQL.
+fileprivate struct GraphQLUnkeyedDecoder: UnkeyedDecodingContainer {
+    var count: Int?
+    var isAtEnd: Bool
+    var currentIndex: Int
+    var codingPath: [CodingKey]
+    var context: GraphQLDecoderContext
+
+    init(codingPath: [CodingKey], context: GraphQLDecoderContext) {
+        self.codingPath = codingPath
+        self.context = context
+        self.currentIndex = 0
+        if context.isActive {
+            self.count = 1
+            self.isAtEnd = false
+            context.activeCodingPath = codingPath
+        } else {
+            self.count = 0
+            self.isAtEnd = true
+        }
+    }
+
+    mutating func decodeNil() throws -> Bool {
+        isAtEnd = true
+        return true
+    }
+
+    mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        context.addProperty(type: [T].self, at: codingPath)
+        isAtEnd = true
+        if let type = T.self as? AnyGraphQLDecodable.Type, let empty = try? type.anyEmptyDecoded() {
+            return empty as! T
+        } else {
+            let decoder = GraphQLDecoder(codingPath: codingPath, context: context)
+            return try T(from: decoder)
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        return .init(GraphQLKeyedDecoder<NestedKey>(codingPath: codingPath, context: context))
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return GraphQLUnkeyedDecoder(codingPath: codingPath, context: context)
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+        return GraphQLDecoder(codingPath: codingPath, context: context)
+    }
+}

--- a/FutureNova/Classes/GraphQLEncoder.swift
+++ b/FutureNova/Classes/GraphQLEncoder.swift
@@ -1,0 +1,78 @@
+//
+//  GraphQLEncoder.swift
+//  FutureNova
+//
+//  Created by Drew Dunne on 5/10/19.
+//
+
+import Foundation
+
+public class GraphQLEncoder {
+
+    /// Encodes a class into a GraphQL query string
+    public static func encodeBody(_ theClass: Decodable.Type) -> String {
+        let encoder = StringEncoder()
+        encoder.encode(theClass)
+        return encoder.asString()
+    }
+
+    /// Encodes arguments into a GraphQL argument tuple
+    public static func encodeArgs(_ dict: [String: CustomStringConvertible]) -> String {
+        var s = "("
+        var i = 0
+        for (key, value) in dict {
+            s += "\(key): \(value)"
+            if i < dict.count - 1 {
+                s += ","
+            }
+            i += 1
+        }
+        s += ")"
+        return s
+    }
+
+    public static func encode(name: String, args: [String: CustomStringConvertible]? = nil,
+                              nestedResponse respClass: Decodable.Type) -> String {
+        let argsStr = args != nil ? encodeArgs(args!) : ""
+        let graphBody = encodeBody(respClass)
+        let graphQl = "{\(name)\(argsStr)\(graphBody)}"
+        #if DEBUG
+        print(graphQl)
+        #endif
+        return graphQl
+    }
+
+    private class StringEncoder {
+
+        private var body: String
+
+        public init() {
+            body = ""
+        }
+
+        public func encode(_ theClass: Decodable.Type) {
+            // Get properties at first depth
+            let props = try! theClass.decodeProperties(depth: 0)
+            body += "{"
+            for prop in props {
+                body += prop.path[0]
+
+                // Check if there are more nested properties
+                if let t = prop.type as? Decodable.Type, try! t.decodeProperties(depth: 0).count > 0 {
+                    encode(t)
+                }
+
+                // Check if we're doing the last property
+                if let last = props.last, last.path != prop.path {
+                    body += ","
+                }
+            }
+            body += "}"
+        }
+
+        public func asString() -> String {
+            return body
+        }
+
+    }
+}


### PR DESCRIPTION
Uses Vapor's Reflectable protocol to try and add GraphQL encoding abilities from Codable structs. This only supports query from GraphQL and not mutation. 