### PR TITLE
Add error-handling for valid response but unsuccessful

### DIFF
--- a/FutureNova.podspec
+++ b/FutureNova.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FutureNova'
-  s.version          = '0.1.5'
+  s.version          = '0.1.6'
   s.summary          = 'A simple networking wrapper using Futures and Promises.'
 
 # This description is used to generate tags and improve search results.

--- a/FutureNova/Classes/Future.swift
+++ b/FutureNova/Classes/Future.swift
@@ -8,6 +8,20 @@
 
 import Foundation
 
+
+extension String: LocalizedError {
+
+    public var errorDescription: String? { return self }
+
+}
+
+struct APIResponse: Codable {
+
+    var success: Bool
+    var error: String?
+
+}
+
 public typealias Networking = (Endpoint) -> Future<Data>
 
 public enum Result<Value> {
@@ -30,6 +44,7 @@ extension Result where Value == Data {
     func decoded<T: Decodable>() throws -> T {
         let decoder = JSONDecoder()
         let data = try resolve()
+        try handleNetworkingError(decoder: decoder, data: data)
         return try decoder.decode(T.self, from: data)
     }
 }
@@ -154,6 +169,7 @@ extension Future where Value == Data {
             // print(String.init(data: $0, encoding: .utf8))
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = Endpoint.config.keyDecodingStrategy
+            try handleNetworkingError(decoder: decoder, data: $0)
             return try decoder.decode(NextValue.self, from: $0)
         }
     }
@@ -164,6 +180,7 @@ extension Future where Value == Data {
             // print(String.init(data: $0, encoding: .utf8))
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = Endpoint.config.keyDecodingStrategy
+            try handleNetworkingError(decoder: decoder, data: $0)
             return try decoder.decode(NextValue.self, from: $0)
         }
     }
@@ -186,4 +203,11 @@ public func chain<A, B, C>(
     // of the inner function into the outer one — but since that
     // now returns another function, we'll also call that one.
     return { outer(inner($0))() }
+}
+
+private func handleNetworkingError(decoder: JSONDecoder, data: Data) throws {
+    let baseData = try decoder.decode(APIResponse.self, from: data)
+    if !baseData.success, let errorString = baseData.error {
+        throw errorString
+    }
 }


### PR DESCRIPTION
We were previously only handling errors that occurred at the networking level (invalid domain, failed requests, faulty connect) but we weren't handling valid responses that returned errors. This would cause any responses that had 
```
success: False,
error: '...',
data: {}
```
to fail when decoding as the JSONDecoder found nothing in data that matched the model that was passed in (unless nothing was given). 

Now we first check to see if success == False and error contains text, and if so, we throw that error in the response so when the user switches on result, they see the proper error string in `case .error(let error)` rather than just seeing the decoding error that would've come with failing to decode data.